### PR TITLE
Updated README.md and Dockerfile from Update 4 to Update 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get update && apt-get install -y \
 # Run this to install gdal dependencies. Later gdal is being reinstalled from source
 RUN apt install -y libpq-dev gdal-bin libgdal-dev
 
-COPY ECWJP2SDKSetup_5.5.0.2268-Update4-Linux.zip ./ECWJP2SDKSetup_5.5.0.2268-Update4-Linux.zip
+COPY ECWJP2SDKSetup_5.5.0.2421-Update6-Linux.zip ./ECWJP2SDKSetup_5.5.0.2421-Update6-Linux.zip
 
 # Install the official ECW JP2 SDK (ECW 5.5 SDK)
-RUN unzip ECWJP2SDKSetup_5.5.0.2268-Update4-Linux.zip \
-    && chmod +x ECWJP2SDKSetup_5.5.0.2268.bin \
-    && ./ECWJP2SDKSetup_5.5.0.2268.bin --accept-eula=YES --install-type=1  \
+RUN unzip ECWJP2SDKSetup_5.5.0.2421-Update6-Linux.zip \
+    && chmod +x ECWJP2SDKSetup_5.5.0.2421.bin \
+    && ./ECWJP2SDKSetup_5.5.0.2421.bin --accept-eula=YES --install-type=1  \
     && cp -r ~/hexagon/ERDAS-ECW_JPEG_2000_SDK-5.5.0/Desktop_Read-Only /usr/local/hexagon \
     && rm -r /usr/local/hexagon/lib/x64 \
     && mv /usr/local/hexagon/lib/cpp11abi/x64 /usr/local/hexagon/lib/x64 \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a Dockerfile and Makefile for converting ECW files to T
 ### Docker Image
 
 The Docker image has GDAL build from source with the ECWJP2 5.5 SDK for ECW support.
-This is based heavily on  hexagon ECWJP2 SDK 5.5. The SDK needs to be downloaded manually from [here](https://supportsi.hexagon.com/s/article/ERDAS-ECW-JP2-SDK-v5-5-Update-4-Release-Announcement?language=en_US) because it requires registration and placed in next to the Dockerfile with the name `ECWJP2SDKSetup_5.5.0.2268-Update4-Linux.zip`. The SDK is then copied into the Docker image and installed.
+This is based heavily on  hexagon ECWJP2 SDK 5.5. The SDK needs to be downloaded manually from [here](https://supportsi.hexagon.com/s/article/ERDAS-ECW-JP2-SDK-Read-Only-Redistributable-Request?language=en_US) because it requires registration and placed in next to the Dockerfile with the name `ECWJP2SDKSetup_5.5.0.2421-Update6-Linux.zip`. The SDK is then copied into the Docker image and installed.
 
 If there is no need for v3 ECW files one can use the version `v0.0.1` which does not require a manual download of the SDK.
 


### PR DESCRIPTION
Due to Update 4 being unavailable for request, I've updated the configuration files to use Update 6. Changes include:
- Updated version references in README.md
- Modified Dockerfile to use Update 6 version